### PR TITLE
Added default name values for -c/--create command

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -16,13 +16,15 @@ class Parser():
     def __init__(self):
         self.games = {}
         self.parser = argparse.ArgumentParser()
-        self.parser.add_argument('-c', '--create', type=self.create_game)
+        self.parser.add_argument('-c', '--create', nargs='?', const='GAME_',
+                                 type=self.create_game)
 
     def create_game(self, name):
-        if name is None:
-            return 'Game name argument is required'
+        if name is 'GAME_':
+            name += str(len(self.games))
         if name in self.games:
-            return 'Game %s already exists' % name
+            return ('Game name "%s" collides with another game. '
+                    'Please provide a different game name.' % name)
         self.games[name] = game.Game(name)
         return 'Created game %s' % name
 

--- a/test.py
+++ b/test.py
@@ -1,7 +1,7 @@
 import parser
 
 p = parser.Parser()
-input = ['-c mango', '--create mango', 'c mango',
+input = ['-c mango', '--create mango', 'c mango', '-c Uguisu',
          '--create kiwi c guava lemon', '--create']
 
 for i in input:


### PR DESCRIPTION
When no game name is provided for the -c/--create argument a default
name of GAME_ is provided and is then checked by create_game so that
the current number of games is added to the end to give it a unique
name.
